### PR TITLE
Use intersect? instead of any? with include?

### DIFF
--- a/lib/random-port/pool.rb
+++ b/lib/random-port/pool.rb
@@ -130,7 +130,7 @@ class RandomPort::Pool
     rescue Errno::EADDRINUSE, SocketError
       return
     end
-    return if opts.any? { |p| @ports.include?(p) }
+    return if opts.intersect?(@ports)
     return unless opts.sum - (total * opts.min) == (total * (total - 1) / 2)
     @ports += opts
     opts


### PR DESCRIPTION
Swaps `opts.any? { |p| @ports.include?(p) }` for `opts.intersect?(@ports)`
in `Pool#take_ports`. Same behaviour, one line shorter.

RuboCop 1.88 turns on `Style/ArrayIntersect`, which rejects the old form.
Three pending dependency bumps (#193, #194, #200) all pull in that RuboCop
and all fail on this one offence, so none of them can land until this is
fixed here first.

`Array#intersect?` arrived in Ruby 3.1 and the gemspec already requires
3.3, so there is no compatibility cost. Once this merges, those three
branches should go green after a rebase.